### PR TITLE
Unsitnize code

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,6 @@
 DOCKER_BASE=ne2harbor.ne.ch/sgrf/sitn
 DOCKER_PORT=5024
 VITE_BASE_PATH=/luftbilder
+VITE_WMTS_CAPABILITIES_URL=https://sitn.ne.ch/mapproxy95/wmts/1.0.0/WMTSCapabilities.xml
+VITE_WMTS_BACKGROUND_LAYER_NAME=plan_ville
+VITE_WMTS_MATRIXSET=EPSG2056

--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 DOCKER_BASE=ne2harbor.ne.ch/sgrf/sitn
 DOCKER_PORT=5024
+VITE_BASE_PATH=/luftbilder

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SITN Luftbilder viewer</title>
+    <title>Luftbilder viewer</title>
   </head>
   <body>
     <div class="container">

--- a/main.js
+++ b/main.js
@@ -1,14 +1,13 @@
 import './style.css';
-import {Map, View} from 'ol';
-import TileLayer  from 'ol/layer/Tile';
+import { Map, View } from 'ol';
+import TileLayer from 'ol/layer/Tile';
 import WebGLTileLayer from 'ol/layer/WebGLTile.js';
 import WMTS from 'ol/source/WMTS';
-import WMTSTileGrid from "ol/tilegrid/WMTS"
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
 import proj4 from 'proj4';
-import {register} from 'ol/proj/proj4.js';
+import { register } from 'ol/proj/proj4.js';
 import Projection from 'ol/proj/Projection';
 import GeoTIFF from 'ol/source/GeoTIFF.js';
-
 
 const params = new URLSearchParams(document.location.search);
 const url = params.get('url');
@@ -17,18 +16,20 @@ const north = parseFloat(params.get('north'));
 const img_type = params.get('type');
 
 const img_type_tag = document.getElementById('image_type');
-(img_type === 'ortho') ? img_type_tag.innerText = "Type d'image: Orthophoto" : img_type_tag.innerText = "Type d'image: Image aérienne";
+img_type === 'ortho'
+  ? img_type_tag.innerText = 'Type d\'image: Orthophoto'
+  : img_type_tag.innerText = 'Type d\'image: Image aérienne';
 
 const img = url.split('/').slice(-1);
 const h5 = document.getElementById('image_id');
-const aTag = document.createElement("a");
+const aTag = document.createElement('a');
 aTag.href = url;
 aTag.innerHTML = img;
 aTag.setAttribute('target', '_blank');
 h5.appendChild(aTag);
 
 const extent = [2420000, 1030000, 2900000, 1360000];
-const crs = "EPSG:2056";
+const crs = 'EPSG:2056';
 const resolutions = [
   250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25, 0.125, 0.0625, 0.03125,
   0.015625, 0.0078125,
@@ -49,7 +50,7 @@ proj4.defs(crs,
   '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333'
   + ' +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel '
   + '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
-    
+
 register(proj4);
 const projection = new Projection({
   code: crs,
@@ -59,30 +60,31 @@ const projection = new Projection({
 const img_layer = new WebGLTileLayer({
   style: {
     color: [
-      "case",
-      ["<", ["*", ["band", 1], 255], 10],
-      ["color", 255, 0, 0, 0],
-      ['color', ["*", ["band", 1], 255], 1]
-  ],},
+      'case',
+      ['<', ['*', ['band', 1], 255], 10],
+      ['color', 255, 0, 0, 0],
+      ['color', ['*', ['band', 1], 255], 1]
+    ],
+  },
   source: new GeoTIFF({
-    sources: [{ url: url, nodata: NaN}]
+    sources: [{ url: url, nodata: NaN }]
   }),
 });
 
 function getWmtsSource(layerName, format) {
   return new WMTS({
     layer: layerName,
-    crossOrigin: "anonymous",
+    crossOrigin: 'anonymous',
     projection,
     url: `https://sitn.ne.ch/mapproxy95/wmts/1.0.0/{layer}/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.${format}`,
     tileGrid,
-    matrixSet: "EPSG2056",
-    style: "default",
-    requestEncoding: "REST",
+    matrixSet: 'EPSG2056',
+    style: 'default',
+    requestEncoding: 'REST',
   });
 }
 
-const plan_ville = new TileLayer({ source: getWmtsSource("plan_ville", "png") });
+const plan_ville = new TileLayer({ source: getWmtsSource('plan_ville', 'png') });
 
 new Map({
   layers: [
@@ -98,7 +100,6 @@ new Map({
     center: [east, north]
   }),
 });
-
 
 const opacityInput = document.getElementById('opacity-input');
 const opacityOutput = document.getElementById('opacity-output');

--- a/main.js
+++ b/main.js
@@ -11,31 +11,35 @@ import GeoTIFF from 'ol/source/GeoTIFF.js';
 import WMTSCapabilities from 'ol/format/WMTSCapabilities';
 import { optionsFromCapabilities } from 'ol/source/WMTS';
 
-const params = new URLSearchParams(document.location.search);
-const url = params.get('url');
-const east = parseFloat(params.get('east'));
-const north = parseFloat(params.get('north'));
-const img_type = params.get('type');
+const urlParams = new URLSearchParams(document.location.search);
+const imageUrl = urlParams.get('url');
+const east = parseFloat(urlParams.get('east'));
+const north = parseFloat(urlParams.get('north'));
+const imageType = urlParams.get('type');
 
-const img_type_tag = document.getElementById('image_type');
-img_type === 'ortho'
-  ? img_type_tag.innerText = 'Type d\'image: Orthophoto'
-  : img_type_tag.innerText = 'Type d\'image: Image aérienne';
+const imageTypeNames = {
+  ortho: 'Orthophoto',
+  aerial: 'Image aérienne',
+};
+const imageTypeText = imageTypeNames[imageType] || 'Inconnu';
+document.getElementById('image_type').innerText = `Type d'image: ${imageTypeText}`;
 
-const img = url.split('/').slice(-1);
-const h5 = document.getElementById('image_id');
-const aTag = document.createElement('a');
-aTag.href = url;
-aTag.innerHTML = img;
-aTag.setAttribute('target', '_blank');
-h5.appendChild(aTag);
+if (imageUrl) {
+  const imageFileName = imageUrl.split('/').pop();
+  const imageIdElement = document.getElementById('image_id');
+  const imageLink = document.createElement('a');
+  imageLink.href = imageUrl;
+  imageLink.innerText = imageFileName;
+  imageLink.setAttribute('target', '_blank');
+  imageIdElement.appendChild(imageLink);
+}
 
 const crs = 'EPSG:2056';
 const matrixSet = import.meta.env.VITE_WMTS_MATRIXSET;
 const capabilitiesUrl = import.meta.env.VITE_WMTS_CAPABILITIES_URL;
 const backgroundLayerName = import.meta.env.VITE_WMTS_BACKGROUND_LAYER_NAME;
 
-let imgLayer;
+let imageLayer;
 
 proj4.defs(crs,
   '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333'
@@ -43,9 +47,7 @@ proj4.defs(crs,
   + '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
 
 register(proj4);
-const projection = new Projection({
-  code: crs,
-});
+const projection = new Projection({ code: crs });
 
 fetch(capabilitiesUrl)
   .then(response => response.text())
@@ -64,29 +66,29 @@ fetch(capabilitiesUrl)
     const resolutions = wmtsSource.getResolutions();
     const matrixIds = resolutions.map((_, index) => index);
     const tileGrid = new WMTSTileGrid({
-        origin: [extent[0], extent[3]],
-        resolutions,
-        matrixIds,
+      origin: [extent[0], extent[3]],
+      resolutions,
+      matrixIds,
     });
 
     wmtsSource.tileGrid = tileGrid;
     wmtsSource.projection = projection;
 
     const backgroundLayer = new TileLayer({
-      source: wmtsSource
+      source: wmtsSource,
     });
 
-    imgLayer = new WebGLTileLayer({
+    imageLayer = new WebGLTileLayer({
       style: {
         color: [
           'case',
           ['<', ['*', ['band', 1], 255], 10],
           ['color', 255, 0, 0, 0],
-          ['color', ['*', ['band', 1], 255], 1]
+          ['color', ['*', ['band', 1], 255], 1],
         ],
       },
       source: new GeoTIFF({
-        sources: [{ url: url, nodata: NaN }]
+        sources: [{ url: imageUrl, nodata: NaN }],
       }),
     });
 
@@ -99,18 +101,20 @@ fetch(capabilitiesUrl)
     });
 
     new Map({
-      layers: [backgroundLayer, imgLayer],
+      layers: [backgroundLayer, imageLayer],
       target: 'sitn-map',
       view,
     });
   });
 
-const opacityInput = document.getElementById('opacity-input');
-const opacityOutput = document.getElementById('opacity-output');
+const opacitySlider = document.getElementById('opacity-input');
+const opacityLabel = document.getElementById('opacity-output');
 
-function update() {
-  const opacity = parseFloat(opacityInput.value);
-  imgLayer.setOpacity(opacity);
-  opacityOutput.innerText = opacity.toFixed(2);
+function updateOpacity() {
+  if (imageLayer) {
+    const opacity = parseFloat(opacitySlider.value);
+    imageLayer.setOpacity(opacity);
+    opacityLabel.innerText = opacity.toFixed(2);
+  }
 }
-opacityInput.addEventListener('input', update);
+opacitySlider.addEventListener('input', updateOpacity);

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,12 @@
 
 This app is used to overlay swisstopo aerial imagery with the SITN basemap.
 
-The base URL has to be called using three parameters:
+The base URL requires three parameters:
 
-* url: the orthophoto URL has given in the swisstopo metadata (see links on that
+* `url`: the orthophoto URL as provided in the swisstopo metadata (see links on that
 page: https://www.swisstopo.admin.ch/fr/imagesaerienne-en-telechargement-20241120)
-* east: the east coordinate of the image center
-* north: the north coordinate of the image center
+* `east`: the east coordinate of the image center
+* `north`: the north coordinate of the image center
 
 Hence, the called URL would be something like:
 * Docker: http://localhost:5024/?east=2559158.53&north=1203713.73&url=https://data.geo.admin.ch/ch.swisstopo.lubis-luftbilder_schwarzweiss/lubis-luftbilder_schwarzweiss_000-321-260/lubis-luftbilder_schwarzweiss_000-321-260_op_2056.tif
@@ -17,42 +17,58 @@ Hence, the called URL would be something like:
 
 ## Getting started
 
-Start a terminal (e.g. Windows PowerShell)
+Start a terminal (e.g. Windows PowerShell) and navigate to the project directory:
 
-Set the working directory to the project directory (*sitn-luftbilder*)
+```sh
+cd sitn-luftbilder
+```
+
+Copy the sample environment file and rename it to `.env`:
+
+```sh
+cp .env.sample .env
+```
+
+Note: the environment variables are prefixed with `VITE_` as required by Vite for client-side usage. Modify them if needed.
 
 Install using npm:
-```
+
+```sh
 npm install
 ```
 
 Build the app with:
-```
+
+```sh
 npm run build
 ```
 
 Run the app locally (on localhost) with:
-```
+
+```sh
 npm start
 ```
 
 ## Docker deployment
 
 To just build locally:
-```
+
+```sh
 cp .env.sample .env
 docker compose build
 ```
 
 To build and run locally:
-```
-docker compose up -d --build 
+
+```sh
+docker compose up -d --build
 ```
 
 To build and run on remote server:
 
-Set the **DOCKER_HOST** environment variable and launch the build/run :
-```
+Set the **DOCKER_HOST** environment variable and launch the build/run:
+
+```sh
 docker compose build
 docker compose push
 $env:DOCKER_HOST="<PATH_TO_REMOTE_HOST>"

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,12 @@
-export default {
-  base: '/luftbilder/', // for local use '',
-  build: {
-    sourcemap: true,
-  }
-}
+import { defineConfig, loadEnv } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), 'VITE_');
+
+  return {
+    base: env.VITE_BASE_PATH,
+    build: {
+      sourcemap: true,
+    }
+  };
+});


### PR DESCRIPTION
Important note: the WMTS configuration is now in the `.env`, so you need to copy the sample file (the sample file is based on the current configration):

```
cp .env.sample .env
```

I also tried with an other WMTS server, with:

```
VITE_WMTS_CAPABILITIES_URL=https://wmts.asit-asso.ch/wmts/?SERVICE=WMTS&REQUEST=GetCapabilities
VITE_WMTS_BACKGROUND_LAYER_NAME=asitvd.fond_couleur
VITE_WMTS_MATRIXSET=2056
```

And the [result](http://localhost:5173/luftbilder/?type=ortho&east=2550902.95&north=1203358.69&url=https://data.geo.admin.ch/ch.swisstopo.lubis-luftbilder_schwarzweiss/lubis-luftbilder_schwarzweiss_000-321-200/lubis-luftbilder_schwarzweiss_000-321-200_op_2056.tif) is:

![image](https://github.com/user-attachments/assets/76ddc627-c088-430b-9ee1-f8e84dded8f5)

And with original values:

![image](https://github.com/user-attachments/assets/15f30eab-cfe8-4e8b-ab65-f787aa3179ec)
